### PR TITLE
Remove yarn files from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,5 @@ node_modules
 examples
 tsconfig.json
 webpack.config.ts
+yarn.lock
+yarn-error.log


### PR DESCRIPTION
The current NPM package contains yarn.lock and yarn-error.log. This adds a lot to the size of the package.

This change prevents those files from being added.